### PR TITLE
Fix invalid grant error message

### DIFF
--- a/lib/omniauth/strategies/dribbble.rb
+++ b/lib/omniauth/strategies/dribbble.rb
@@ -40,7 +40,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/v1/user').parsed
+        @raw_info ||= access_token.get('/v2/user').parsed
       end
 
       def callback_url

--- a/lib/omniauth/strategies/dribbble.rb
+++ b/lib/omniauth/strategies/dribbble.rb
@@ -42,6 +42,10 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get('/v1/user').parsed
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end

--- a/spec/omniauth/strategies/dribbble_spec.rb
+++ b/spec/omniauth/strategies/dribbble_spec.rb
@@ -8,7 +8,7 @@ describe OmniAuth::Strategies::Dribbble do
   subject { OmniAuth::Strategies::Dribbble.new({}) }
 
   before do
-    subject.stub(:access_token).and_return(access_token)
+    allow(subject).to receive(:access_token).and_return(access_token)
   end
 
   context 'client options' do
@@ -27,7 +27,7 @@ describe OmniAuth::Strategies::Dribbble do
 
   context '#raw_info' do
     it 'uses absolute paths' do
-      access_token.should_receive(:get).with('/v1/user').and_return(response)
+      expect(access_token).to receive(:get).with('/v1/user').and_return(response)
       expect(subject.raw_info).to eq(parsed_response)
     end
   end

--- a/spec/omniauth/strategies/dribbble_spec.rb
+++ b/spec/omniauth/strategies/dribbble_spec.rb
@@ -31,4 +31,13 @@ describe OmniAuth::Strategies::Dribbble do
       expect(subject.raw_info).to eq(parsed_response)
     end
   end
+
+  context '#callback_phase' do
+    it 'does not contains query_string in callback_url' do
+      allow(subject).to receive(:full_host).and_return('full_host')
+      allow(subject).to receive(:script_name).and_return('dribbble')
+      allow(subject).to receive(:query_string).and_return('query_string')
+      expect(subject.callback_url).to_not include('query_string')
+    end
+  end
 end


### PR DESCRIPTION
Wasn't possible to use auth with dribbble, callback url uses query string by default, this parameter breaks request with dribbble and always returned invalid grant.
The solution was override callback_url omniauth method
